### PR TITLE
fix sorting by more than one column

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -191,7 +191,8 @@ module.exports = function (options) {
      */
     function buildOrderingPartial(requestQuery) {
         var query = [];
-        for (var fdx = 0; fdx < _u.isArray(requestQuery.order) ? requestQuery.order.length : 0; ++fdx) {
+        var l = _u.isArray(requestQuery.order) ? requestQuery.order.length : 0;
+        for (var fdx = 0; fdx < l; ++fdx) {
             var order = requestQuery.order[fdx],
                 column = requestQuery.columns[order.column];
 


### PR DESCRIPTION
fixed that you can order by more than one column. At the moment you still order by only one column even if you SHIFT+LEFTCLICK more than one column.