### PR TITLE
Fix(recordsTotal): do not use search string for total count

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -258,10 +258,10 @@ module.exports = function (options) {
         }
         queries.recordsTotal = buildCountStatement(requestQuery);
         if (searchString) {
-            queries.recordsFiltered = buildCountStatement(requestQuery, true);
+            queries.recordsFiltered = buildCountStatement(requestQuery, true); // Use search string if provided.
         }
         var query = buildSelectPartial();
-        query += buildWherePartial(requestQuery);
+        query += buildWherePartial(requestQuery, true); // Use search string if provided.
         query += buildOrderingPartial(requestQuery);
         query += buildLimitPartial(requestQuery);
         if (self.dbType === 'oracle'){

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -74,17 +74,18 @@ module.exports = function (options) {
 
     /**
      * (private) Build a complete SELECT statement that counts the number of entries.
-     * @param searchString If specified then produces a statement to count the filtered list of records.
+     * @param requestQuery
+     * @param useSearch If true then produces a statement to count the filtered list of records.
      * Otherwise the statement counts the unfiltered list of records.
-     * @return {String} A complete SELECT statement
+     * @returns {string} A complete SELECT statement
      */
-    function buildCountStatement(requestQuery) {
-        var dateSql = buildDatePartial();
+    function buildCountStatement(requestQuery, useSearch) {
+        //var dateSql = buildDatePartial();
         var result = "SELECT COUNT(";
         result += self.sSelectSql ? "*" : (self.sCountColumnName ? self.sCountColumnName : "id");
         result += ") FROM ";
         result += self.sFromSql ? self.sFromSql : self.sTableName;
-        result += buildWherePartial(requestQuery);
+        result += buildWherePartial(requestQuery, useSearch);
 //        var sSearchQuery = buildSearchPartial( sSearchString );
 //        var sWheres = sSearchQuery ? [ sSearchQuery ] : [];
 //        if( self.sWhereAndSql )
@@ -99,14 +100,19 @@ module.exports = function (options) {
     /**
      * (private) Build the WHERE clause
      * otherwise uses aoColumnDef mData property.
-     * @param searchString
-     * @return {String}
+     * @param requestQuery
+     * @param useSearch If true, includes the search partial in the query.
+     * @returns {string}
      */
-    function buildWherePartial(requestQuery) {
+    function buildWherePartial(requestQuery, useSearch) {
         var sWheres = [];
-        var searchQuery = buildSearchPartial(requestQuery);
-        if (searchQuery)
-            sWheres.push(searchQuery);
+
+        if (useSearch) {
+            var searchQuery = buildSearchPartial(requestQuery);
+            if (searchQuery)
+                sWheres.push(searchQuery);
+        }
+
         if (self.sWhereAndSql)
             sWheres.push(self.sWhereAndSql);
         var dateSql = buildDatePartial();
@@ -252,7 +258,7 @@ module.exports = function (options) {
         }
         queries.recordsTotal = buildCountStatement(requestQuery);
         if (searchString) {
-            queries.recordsFiltered = buildCountStatement(requestQuery);
+            queries.recordsFiltered = buildCountStatement(requestQuery, true);
         }
         var query = buildSelectPartial();
         query += buildWherePartial(requestQuery);


### PR DESCRIPTION
Hi,

This PR fixes https://github.com/jpravetz/node-datatable/issues/21

It adds a new parameter to `buildCountStatement` and `buildWherePartial` private functions, so that we can differentiate `recordsTotal` and `recordsFiltered` built queries.

See it in action: https://plnkr.co/edit/4VHcTgRzFziLQ9K8RUST?p=preview