### PR TITLE
Fix(order&search): accept column options as boolean

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -149,7 +149,7 @@ module.exports = function (options) {
             customColumns = _u.isArray(self.aSearchColumns) && !_u.isEmpty(self.aSearchColumns) && global;
 
         _u.each(customColumns ? self.aSearchColumns : requestQuery.columns, function(column){
-            if (customColumns || column.searchable === 'true'){
+            if (customColumns || (typeof column.searchable === 'boolean' && column.searchable) || column.searchable === 'true'){
                 var colName = sanitize(customColumns ? column : column.name),
                     searchVal = sanitize(global ? requestQuery.search.value : column.search.value);
 

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -196,7 +196,7 @@ module.exports = function (options) {
             var order = requestQuery.order[fdx],
                 column = requestQuery.columns[order.column];
 
-            if (column.orderable === 'true' && column.name) {
+            if (((typeof column.orderable === 'boolean' && column.orderable) || column.orderable === 'true') && column.name) {
                 query.push(column.name + " " + order.dir);
             }
         }


### PR DESCRIPTION
This PR fixes https://github.com/jpravetz/node-datatable/issues/19

It accepts `column.orderable` and `column.searchable` options as booleans (as passed by DataTables in the `requestQuery`), instead of expecting only a string value.

See it in action: https://plnkr.co/edit/t8tUOqHQjGZFhO1ePXHS?p=preview